### PR TITLE
Implement CCP CLI for fine-tuning workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,19 +136,65 @@ dev/
 
 - `/fix-issue <number>` - Fetch GitHub issue and implement with full workflow
 
-## Key Commands
+## CCP CLI
+
+The project includes a CLI for all fine-tuning and evaluation operations:
 
 ```bash
-# Training
+# Show all commands
+python ccp_cli.py --help
+
+# Validate training data
+python ccp_cli.py validate-data
+python ccp_cli.py validate-data --file data/ccp_training_with_reasoning.jsonl --verbose
+
+# Train the model
+python ccp_cli.py train --dry-run              # Validate setup without training
+python ccp_cli.py train                         # Run training with defaults
+python ccp_cli.py train --epochs 5 --lr 1e-4   # Custom parameters
+python ccp_cli.py train --resume-from latest   # Resume from checkpoint
+
+# Evaluate model performance
+python ccp_cli.py eval --quick                 # Quick eval (5 examples)
+python ccp_cli.py eval --model finetuned       # Full evaluation
+python ccp_cli.py eval --category adversarial  # Filter by category
+
+# Run inference on a single prompt
+python ccp_cli.py inference "Show me my best accounts"
+python ccp_cli.py inference "Accounts at risk" --json-only | jq .
+
+# View evaluation history
+python ccp_cli.py history
+python ccp_cli.py history --compare 2          # Compare last 2 runs
+python ccp_cli.py history --detail latest      # Detailed view
+python ccp_cli.py history --export results.csv # Export to CSV
+```
+
+### CLI Options
+
+| Command | Description |
+|---------|-------------|
+| `validate-data` | Validate training data schema and content |
+| `train` | Fine-tune the CCP model with checkpoint resume support |
+| `eval` | Evaluate model performance against test set |
+| `inference` | Run single inference on a GTM prompt |
+| `history` | View and analyze evaluation history |
+
+## Legacy Commands
+
+The following standalone scripts are still available:
+
+```bash
+# Training (notebook)
 jupyter notebook fine_tune_llm_mac_mps.ipynb
 
 # Testing
 python simple_test.py
 
-# Evaluation
+# Evaluation (legacy)
 python run_evals.py --quick
 python eval_history.py --detail latest
 
-# Data validation
+# Data validation (one-liner)
 python -c "import json; [json.loads(l) for l in open('data/ccp_training_with_reasoning.jsonl')]"
 ```

--- a/ccp/__init__.py
+++ b/ccp/__init__.py
@@ -1,0 +1,7 @@
+"""
+CCP - Context Collapse Parser CLI
+
+A CLI tool for fine-tuning and running the Phoenix Context Collapse Parser.
+"""
+
+__version__ = "0.1.0"

--- a/ccp/cli.py
+++ b/ccp/cli.py
@@ -1,0 +1,65 @@
+"""
+CCP CLI - Context Collapse Parser Command Line Interface
+
+Main entry point for all CCP commands.
+"""
+
+import click
+
+from ccp import __version__
+from ccp.commands.validate import validate_data
+from ccp.commands.train import train
+from ccp.commands.eval import eval_cmd
+from ccp.commands.inference import inference
+from ccp.commands.history import history
+
+
+@click.group()
+@click.version_option(version=__version__, prog_name="ccp")
+@click.option(
+    "--verbose", "-v",
+    is_flag=True,
+    help="Enable verbose output"
+)
+@click.pass_context
+def cli(ctx, verbose):
+    """CCP - Context Collapse Parser CLI
+
+    A command-line tool for fine-tuning and running the Phoenix
+    Context Collapse Parser for GTM intent recognition.
+
+    \b
+    Commands:
+      validate-data  Validate training data schema
+      train          Fine-tune the CCP model
+      eval           Evaluate model performance
+      inference      Run inference on a single prompt
+      history        View evaluation history
+
+    \b
+    Examples:
+      ccp validate-data --file data/ccp_training_with_reasoning.jsonl
+      ccp train --epochs 3 --resume-from latest
+      ccp eval --quick
+      ccp inference "Show me my best accounts"
+      ccp history --compare 2
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["verbose"] = verbose
+
+
+# Register commands
+cli.add_command(validate_data)
+cli.add_command(train)
+cli.add_command(eval_cmd, name="eval")
+cli.add_command(inference)
+cli.add_command(history)
+
+
+def main():
+    """Main entry point."""
+    cli(obj={})
+
+
+if __name__ == "__main__":
+    main()

--- a/ccp/commands/__init__.py
+++ b/ccp/commands/__init__.py
@@ -1,0 +1,1 @@
+"""CCP CLI commands."""

--- a/ccp/commands/eval.py
+++ b/ccp/commands/eval.py
@@ -1,0 +1,460 @@
+"""
+CCP eval command.
+
+Runs evaluation on the fine-tuned CCP model.
+"""
+
+import json
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any, Optional, List
+
+import click
+import torch
+
+from ccp.config import (
+    CCP_SYSTEM_PROMPT,
+    EVAL_FIELDS,
+)
+from ccp.model import load_finetuned_model, load_base_model, load_tokenizer, clear_memory
+from ccp.data import load_eval_dataset
+from ccp.utils.parsing import parse_ccp_response, format_inference_prompt
+
+
+def generate_response(
+    model,
+    tokenizer,
+    prompt: str,
+    max_new_tokens: int = 800,
+    temperature: float = 0.1,
+) -> str:
+    """Generate a response from the model."""
+    inputs = tokenizer(prompt, return_tensors="pt")
+    inputs = {k: v.to(model.device) for k, v in inputs.items()}
+
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            do_sample=True,
+            pad_token_id=tokenizer.pad_token_id,
+        )
+
+    response = tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+    # Remove prompt from response
+    if prompt in response:
+        response = response[len(prompt):]
+
+    return response
+
+
+def score_response(
+    predicted: Optional[Dict],
+    expected: Dict,
+    is_valid_json: bool
+) -> Dict[str, Any]:
+    """Score a predicted response against expected."""
+    scores = {
+        "json_valid": is_valid_json,
+        "field_scores": {},
+        "field_accuracy": 0.0,
+        "reasoning_present": False,
+        "clarification_correct": False,
+    }
+
+    if not is_valid_json or predicted is None:
+        return scores
+
+    # Score each field
+    matches = 0
+    total = 0
+
+    for field in EVAL_FIELDS:
+        if field in expected:
+            total += 1
+            pred_val = predicted.get(field)
+            exp_val = expected.get(field)
+
+            # Handle None/null comparison
+            if pred_val is None and exp_val is None:
+                match = True
+            elif pred_val is None or exp_val is None:
+                match = False
+            else:
+                match = str(pred_val).lower() == str(exp_val).lower()
+
+            scores["field_scores"][field] = match
+            if match:
+                matches += 1
+
+    scores["field_accuracy"] = matches / total if total > 0 else 0.0
+
+    # Check clarification_needed specifically
+    if "clarification_needed" in expected:
+        scores["clarification_correct"] = (
+            predicted.get("clarification_needed") == expected.get("clarification_needed")
+        )
+
+    return scores
+
+
+@click.command("eval")
+@click.option(
+    "--model", "model_type",
+    default="finetuned",
+    type=click.Choice(["finetuned", "base", "both"]),
+    help="Which model(s) to evaluate"
+)
+@click.option(
+    "--model-path",
+    default="./models/phi-2",
+    help="Path to base model"
+)
+@click.option(
+    "--adapter-path",
+    default="./ccp-adapter",
+    help="Path to LoRA adapter"
+)
+@click.option(
+    "--eval-data",
+    default="./data/ccp_eval.jsonl",
+    help="Path to evaluation data"
+)
+@click.option(
+    "--category",
+    default=None,
+    type=click.Choice(["standard", "slang", "adversarial", "ambiguous"]),
+    help="Filter by category"
+)
+@click.option(
+    "--quick",
+    is_flag=True,
+    help="Quick eval with 5 examples"
+)
+@click.option(
+    "--limit",
+    default=None,
+    type=int,
+    help="Limit number of examples"
+)
+@click.option(
+    "--verbose", "-v",
+    is_flag=True,
+    help="Show detailed output"
+)
+@click.option(
+    "--no-save",
+    is_flag=True,
+    help="Don't save results to file"
+)
+@click.option(
+    "--results-dir",
+    default="./eval_results",
+    help="Directory to save results"
+)
+@click.option(
+    "--compare",
+    is_flag=True,
+    help="Compare with previous run"
+)
+def eval_cmd(
+    model_type: str,
+    model_path: str,
+    adapter_path: str,
+    eval_data: str,
+    category: Optional[str],
+    quick: bool,
+    limit: Optional[int],
+    verbose: bool,
+    no_save: bool,
+    results_dir: str,
+    compare: bool,
+):
+    """Evaluate CCP model performance.
+
+    Runs the model on evaluation examples and scores the results
+    for JSON validity, field accuracy, and per-field metrics.
+
+    Examples:
+
+        # Quick evaluation (5 examples)
+        ccp eval --quick
+
+        # Full evaluation of fine-tuned model
+        ccp eval --model finetuned
+
+        # Evaluate specific category
+        ccp eval --category adversarial
+
+        # Compare both models
+        ccp eval --model both
+    """
+    click.echo("=" * 60)
+    click.echo("CCP Evaluation")
+    click.echo("=" * 60)
+
+    # Determine limit
+    if quick:
+        limit = 5
+    elif limit is None:
+        limit = None  # No limit
+
+    # Load eval data
+    if not Path(eval_data).exists():
+        click.echo(f"Error: Eval data not found: {eval_data}", err=True)
+        raise SystemExit(1)
+
+    examples = load_eval_dataset(eval_data, category=category, limit=limit)
+    click.echo(f"\nLoaded {len(examples)} evaluation examples")
+    if category:
+        click.echo(f"  Category filter: {category}")
+
+    results = {}
+
+    # Evaluate models
+    models_to_eval = []
+    if model_type in ["finetuned", "both"]:
+        models_to_eval.append("finetuned")
+    if model_type in ["base", "both"]:
+        models_to_eval.append("base")
+
+    for mt in models_to_eval:
+        click.echo(f"\n{'=' * 60}")
+        click.echo(f"Evaluating: {mt.upper()} model")
+        click.echo("=" * 60)
+
+        # Load model
+        if mt == "finetuned":
+            if not Path(adapter_path).exists():
+                click.echo(f"Error: Adapter not found: {adapter_path}", err=True)
+                continue
+            model, tokenizer = load_finetuned_model(model_path, adapter_path)
+        else:
+            tokenizer = load_tokenizer(model_path)
+            model = load_base_model(model_path)
+            model.eval()
+
+        # Run evaluation
+        eval_results = run_evaluation(model, tokenizer, examples, mt, verbose)
+        results[mt] = eval_results
+
+        # Print results
+        print_results(eval_results, mt)
+
+        # Clear memory
+        del model
+        clear_memory()
+
+    # Save results
+    if not no_save:
+        save_results(results, results_dir, model_type)
+
+    # Compare with previous
+    if compare and not no_save:
+        compare_with_previous(results, results_dir, model_type)
+
+
+def run_evaluation(
+    model,
+    tokenizer,
+    examples: List[Dict],
+    model_type: str,
+    verbose: bool
+) -> Dict[str, Any]:
+    """Run evaluation on examples."""
+    results = {
+        "model_type": model_type,
+        "timestamp": datetime.now().isoformat(),
+        "num_examples": len(examples),
+        "overall": {
+            "json_valid": 0,
+            "field_accuracy": 0.0,
+            "total_latency_ms": 0,
+        },
+        "by_category": {},
+        "by_difficulty": {},
+        "by_field": {field: {"correct": 0, "total": 0} for field in EVAL_FIELDS},
+        "examples": [],
+    }
+
+    for idx, example in enumerate(examples):
+        if verbose:
+            click.echo(f"\n[{idx+1}/{len(examples)}] {example['gtm_prompt'][:50]}...")
+
+        # Format prompt
+        if model_type == "finetuned":
+            prompt = format_inference_prompt(example["gtm_prompt"], CCP_SYSTEM_PROMPT)
+        else:
+            prompt = f"### GTM Prompt:\n{example['gtm_prompt']}\n\n### Response:\n"
+
+        # Generate
+        start_time = time.time()
+        response = generate_response(model, tokenizer, prompt)
+        latency_ms = (time.time() - start_time) * 1000
+
+        # Parse response
+        reasoning, intent_ir, is_valid = parse_ccp_response(response)
+
+        # Score
+        expected = example.get("expected", example.get("intent_ir", {}))
+        scores = score_response(intent_ir, expected, is_valid)
+        scores["latency_ms"] = latency_ms
+        scores["reasoning_present"] = reasoning is not None and len(reasoning or "") > 10
+
+        # Update overall stats
+        if is_valid:
+            results["overall"]["json_valid"] += 1
+        results["overall"]["field_accuracy"] += scores["field_accuracy"]
+        results["overall"]["total_latency_ms"] += latency_ms
+
+        # Update by category
+        cat = example.get("category", "unknown")
+        if cat not in results["by_category"]:
+            results["by_category"][cat] = {"json_valid": 0, "field_accuracy": 0, "count": 0}
+        results["by_category"][cat]["count"] += 1
+        if is_valid:
+            results["by_category"][cat]["json_valid"] += 1
+        results["by_category"][cat]["field_accuracy"] += scores["field_accuracy"]
+
+        # Update by difficulty
+        diff = example.get("difficulty", "unknown")
+        if diff not in results["by_difficulty"]:
+            results["by_difficulty"][diff] = {"json_valid": 0, "field_accuracy": 0, "count": 0}
+        results["by_difficulty"][diff]["count"] += 1
+        if is_valid:
+            results["by_difficulty"][diff]["json_valid"] += 1
+        results["by_difficulty"][diff]["field_accuracy"] += scores["field_accuracy"]
+
+        # Update by field
+        for field, correct in scores["field_scores"].items():
+            results["by_field"][field]["total"] += 1
+            if correct:
+                results["by_field"][field]["correct"] += 1
+
+        # Store example result
+        results["examples"].append({
+            "prompt": example["gtm_prompt"],
+            "category": cat,
+            "difficulty": diff,
+            "is_valid": is_valid,
+            "field_accuracy": scores["field_accuracy"],
+            "latency_ms": latency_ms,
+        })
+
+        if verbose:
+            status = "VALID" if is_valid else "INVALID"
+            click.echo(f"  JSON: {status}, Accuracy: {scores['field_accuracy']:.1%}, Latency: {latency_ms:.0f}ms")
+
+    # Compute averages
+    n = len(examples)
+    if n > 0:
+        results["overall"]["json_valid_rate"] = results["overall"]["json_valid"] / n
+        results["overall"]["field_accuracy"] = results["overall"]["field_accuracy"] / n
+        results["overall"]["avg_latency_ms"] = results["overall"]["total_latency_ms"] / n
+
+    for cat in results["by_category"]:
+        c = results["by_category"][cat]["count"]
+        if c > 0:
+            results["by_category"][cat]["json_valid_rate"] = results["by_category"][cat]["json_valid"] / c
+            results["by_category"][cat]["field_accuracy"] = results["by_category"][cat]["field_accuracy"] / c
+
+    for diff in results["by_difficulty"]:
+        d = results["by_difficulty"][diff]["count"]
+        if d > 0:
+            results["by_difficulty"][diff]["json_valid_rate"] = results["by_difficulty"][diff]["json_valid"] / d
+            results["by_difficulty"][diff]["field_accuracy"] = results["by_difficulty"][diff]["field_accuracy"] / d
+
+    return results
+
+
+def print_results(results: Dict, model_type: str):
+    """Print evaluation results."""
+    click.echo(f"\n{'Results':=^60}")
+
+    overall = results["overall"]
+    click.echo(f"\n  JSON Valid Rate:    {overall.get('json_valid_rate', 0):.1%}")
+    click.echo(f"  Field Accuracy:     {overall.get('field_accuracy', 0):.1%}")
+    click.echo(f"  Avg Latency:        {overall.get('avg_latency_ms', 0):.0f}ms")
+
+    # By category
+    if results["by_category"]:
+        click.echo(f"\n  {'By Category':-^50}")
+        for cat, stats in sorted(results["by_category"].items()):
+            click.echo(
+                f"    {cat:15} JSON: {stats.get('json_valid_rate', 0):.1%}, "
+                f"Accuracy: {stats.get('field_accuracy', 0):.1%} (n={stats['count']})"
+            )
+
+    # By field
+    click.echo(f"\n  {'By Field':-^50}")
+    for field, stats in results["by_field"].items():
+        if stats["total"] > 0:
+            acc = stats["correct"] / stats["total"]
+            click.echo(f"    {field:25} {acc:.1%} ({stats['correct']}/{stats['total']})")
+
+
+def save_results(results: Dict, results_dir: str, model_type: str):
+    """Save results to file."""
+    results_path = Path(results_dir)
+    results_path.mkdir(exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    for mt, data in results.items():
+        filename = f"eval_{mt}_{timestamp}.json"
+        filepath = results_path / filename
+
+        with open(filepath, "w") as f:
+            json.dump(data, f, indent=2)
+
+        click.echo(f"\nResults saved to: {filepath}")
+
+        # Update latest symlink
+        latest_link = results_path / f"latest_{mt}.json"
+        if latest_link.exists():
+            latest_link.unlink()
+        latest_link.symlink_to(filename)
+
+
+def compare_with_previous(results: Dict, results_dir: str, model_type: str):
+    """Compare with previous evaluation results."""
+    results_path = Path(results_dir)
+
+    for mt in results:
+        latest_link = results_path / f"latest_{mt}.json"
+        if not latest_link.exists():
+            continue
+
+        # Find previous (second latest)
+        all_files = sorted(
+            results_path.glob(f"eval_{mt}_*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True
+        )
+
+        if len(all_files) < 2:
+            continue
+
+        previous_file = all_files[1]
+        with open(previous_file) as f:
+            previous = json.load(f)
+
+        current = results[mt]
+
+        click.echo(f"\n{'Comparison with Previous':=^60}")
+        click.echo(f"  Previous: {previous_file.name}")
+
+        prev_json = previous["overall"].get("json_valid_rate", 0)
+        curr_json = current["overall"].get("json_valid_rate", 0)
+        diff_json = curr_json - prev_json
+
+        prev_acc = previous["overall"].get("field_accuracy", 0)
+        curr_acc = current["overall"].get("field_accuracy", 0)
+        diff_acc = curr_acc - prev_acc
+
+        click.echo(f"\n  JSON Valid Rate:  {curr_json:.1%} ({diff_json:+.1%})")
+        click.echo(f"  Field Accuracy:   {curr_acc:.1%} ({diff_acc:+.1%})")

--- a/ccp/commands/history.py
+++ b/ccp/commands/history.py
@@ -1,0 +1,325 @@
+"""
+CCP history command.
+
+View and analyze evaluation history.
+"""
+
+import json
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Optional
+
+import click
+
+
+def load_all_results(results_dir: str) -> List[Dict]:
+    """Load all evaluation results, sorted by timestamp descending."""
+    results_path = Path(results_dir)
+    if not results_path.exists():
+        return []
+
+    results = []
+    for filepath in results_path.glob("eval_*.json"):
+        # Skip symlinks
+        if filepath.is_symlink():
+            continue
+
+        try:
+            with open(filepath) as f:
+                data = json.load(f)
+                data["_filepath"] = str(filepath)
+                data["_filename"] = filepath.name
+                results.append(data)
+        except (json.JSONDecodeError, IOError):
+            continue
+
+    # Sort by timestamp descending
+    results.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
+    return results
+
+
+@click.command("history")
+@click.option(
+    "--results-dir",
+    default="./eval_results",
+    help="Directory containing evaluation results"
+)
+@click.option(
+    "--model", "model_type",
+    default="finetuned",
+    type=click.Choice(["finetuned", "base", "all"]),
+    help="Filter by model type"
+)
+@click.option(
+    "--compare",
+    default=None,
+    type=int,
+    help="Compare last N runs"
+)
+@click.option(
+    "--detail",
+    default=None,
+    help="Show detailed results (use 'latest' or index number)"
+)
+@click.option(
+    "--export",
+    default=None,
+    type=click.Path(),
+    help="Export history to CSV file"
+)
+def history(
+    results_dir: str,
+    model_type: str,
+    compare: Optional[int],
+    detail: Optional[str],
+    export: Optional[str],
+):
+    """View and analyze evaluation history.
+
+    Shows a summary of past evaluation runs with metrics and trends.
+
+    Examples:
+
+        # View history summary
+        ccp history
+
+        # Compare last 2 runs
+        ccp history --compare 2
+
+        # Show detailed results for latest run
+        ccp history --detail latest
+
+        # Export to CSV
+        ccp history --export results.csv
+    """
+    results = load_all_results(results_dir)
+
+    if not results:
+        click.echo(f"No evaluation results found in {results_dir}")
+        return
+
+    # Filter by model type
+    if model_type != "all":
+        results = [r for r in results if r.get("model_type") == model_type]
+
+    if not results:
+        click.echo(f"No results found for model type: {model_type}")
+        return
+
+    if export:
+        export_to_csv(results, export)
+        return
+
+    if detail:
+        show_detail(results, detail)
+        return
+
+    if compare:
+        compare_runs(results, compare)
+        return
+
+    # Default: show summary
+    show_summary(results, model_type)
+
+
+def show_summary(results: List[Dict], model_type: str):
+    """Show summary of evaluation history."""
+    click.echo("=" * 70)
+    click.echo(f"CCP Evaluation History ({model_type})")
+    click.echo("=" * 70)
+
+    click.echo(f"\n{'#':<4} {'Date':<20} {'Examples':<10} {'JSON OK':<10} {'Accuracy':<10} {'Trend':<8}")
+    click.echo("-" * 70)
+
+    prev_accuracy = None
+    for idx, result in enumerate(results[:20]):  # Show last 20
+        timestamp = result.get("timestamp", "Unknown")
+        try:
+            dt = datetime.fromisoformat(timestamp)
+            date_str = dt.strftime("%Y-%m-%d %H:%M")
+        except (ValueError, TypeError):
+            date_str = timestamp[:16] if timestamp else "Unknown"
+
+        n_examples = result.get("num_examples", 0)
+        overall = result.get("overall", {})
+        json_rate = overall.get("json_valid_rate", 0)
+        accuracy = overall.get("field_accuracy", 0)
+
+        # Trend indicator
+        if prev_accuracy is not None:
+            diff = accuracy - prev_accuracy
+            if diff > 0.01:
+                trend = "UP"
+            elif diff < -0.01:
+                trend = "DOWN"
+            else:
+                trend = "-"
+        else:
+            trend = "-"
+        prev_accuracy = accuracy
+
+        click.echo(
+            f"{idx:<4} {date_str:<20} {n_examples:<10} {json_rate:<10.1%} {accuracy:<10.1%} {trend:<8}"
+        )
+
+    click.echo("\n" + "=" * 70)
+    click.echo(f"Total runs: {len(results)}")
+
+
+def compare_runs(results: List[Dict], n: int):
+    """Compare last N runs."""
+    if len(results) < n:
+        click.echo(f"Only {len(results)} runs available, comparing all")
+        n = len(results)
+
+    runs_to_compare = results[:n]
+
+    click.echo("=" * 70)
+    click.echo(f"Comparing Last {n} Runs")
+    click.echo("=" * 70)
+
+    # Header
+    header = f"{'Metric':<25}"
+    for idx, run in enumerate(runs_to_compare):
+        timestamp = run.get("timestamp", "Unknown")[:10]
+        header += f" {timestamp:<12}"
+    click.echo(header)
+    click.echo("-" * 70)
+
+    # Metrics
+    metrics = [
+        ("Examples", "num_examples"),
+        ("JSON Valid Rate", ("overall", "json_valid_rate"), True),
+        ("Field Accuracy", ("overall", "field_accuracy"), True),
+        ("Avg Latency (ms)", ("overall", "avg_latency_ms"), False),
+    ]
+
+    for metric_name, path, is_pct in [m if len(m) == 3 else (*m, False) for m in metrics]:
+        row = f"{metric_name:<25}"
+        for run in runs_to_compare:
+            if isinstance(path, tuple):
+                value = run.get(path[0], {}).get(path[1], 0)
+            else:
+                value = run.get(path, 0)
+
+            if is_pct:
+                row += f" {value:<12.1%}"
+            elif isinstance(value, float):
+                row += f" {value:<12.1f}"
+            else:
+                row += f" {value:<12}"
+        click.echo(row)
+
+    # Delta if comparing 2
+    if n == 2:
+        click.echo("\n" + "-" * 70)
+        click.echo("Delta (newer - older):")
+
+        curr = runs_to_compare[0]
+        prev = runs_to_compare[1]
+
+        curr_json = curr.get("overall", {}).get("json_valid_rate", 0)
+        prev_json = prev.get("overall", {}).get("json_valid_rate", 0)
+        curr_acc = curr.get("overall", {}).get("field_accuracy", 0)
+        prev_acc = prev.get("overall", {}).get("field_accuracy", 0)
+
+        click.echo(f"  JSON Valid Rate: {curr_json - prev_json:+.1%}")
+        click.echo(f"  Field Accuracy:  {curr_acc - prev_acc:+.1%}")
+
+
+def show_detail(results: List[Dict], detail: str):
+    """Show detailed results for a specific run."""
+    if detail == "latest":
+        idx = 0
+    else:
+        try:
+            idx = int(detail)
+        except ValueError:
+            click.echo(f"Invalid detail argument: {detail}")
+            return
+
+    if idx >= len(results):
+        click.echo(f"Run index {idx} not found (only {len(results)} runs available)")
+        return
+
+    result = results[idx]
+
+    click.echo("=" * 70)
+    click.echo("Detailed Evaluation Results")
+    click.echo("=" * 70)
+
+    click.echo(f"\nFile: {result.get('_filename', 'Unknown')}")
+    click.echo(f"Timestamp: {result.get('timestamp', 'Unknown')}")
+    click.echo(f"Model Type: {result.get('model_type', 'Unknown')}")
+    click.echo(f"Examples: {result.get('num_examples', 0)}")
+
+    # Overall metrics
+    overall = result.get("overall", {})
+    click.echo(f"\n{'Overall Metrics':-^60}")
+    click.echo(f"  JSON Valid Rate:    {overall.get('json_valid_rate', 0):.1%}")
+    click.echo(f"  Field Accuracy:     {overall.get('field_accuracy', 0):.1%}")
+    click.echo(f"  Avg Latency:        {overall.get('avg_latency_ms', 0):.0f}ms")
+
+    # By category
+    by_category = result.get("by_category", {})
+    if by_category:
+        click.echo(f"\n{'By Category':-^60}")
+        for cat, stats in sorted(by_category.items()):
+            click.echo(
+                f"  {cat:15} JSON: {stats.get('json_valid_rate', 0):.1%}, "
+                f"Acc: {stats.get('field_accuracy', 0):.1%} (n={stats.get('count', 0)})"
+            )
+
+    # By difficulty
+    by_difficulty = result.get("by_difficulty", {})
+    if by_difficulty:
+        click.echo(f"\n{'By Difficulty':-^60}")
+        for diff, stats in sorted(by_difficulty.items()):
+            click.echo(
+                f"  {diff:15} JSON: {stats.get('json_valid_rate', 0):.1%}, "
+                f"Acc: {stats.get('field_accuracy', 0):.1%} (n={stats.get('count', 0)})"
+            )
+
+    # By field
+    by_field = result.get("by_field", {})
+    if by_field:
+        click.echo(f"\n{'By Field':-^60}")
+        for field, stats in by_field.items():
+            total = stats.get("total", 0)
+            correct = stats.get("correct", 0)
+            if total > 0:
+                acc = correct / total
+                click.echo(f"  {field:25} {acc:.1%} ({correct}/{total})")
+
+
+def export_to_csv(results: List[Dict], output_path: str):
+    """Export results to CSV."""
+    with open(output_path, "w", newline="") as f:
+        writer = csv.writer(f)
+
+        # Header
+        writer.writerow([
+            "timestamp",
+            "model_type",
+            "num_examples",
+            "json_valid_rate",
+            "field_accuracy",
+            "avg_latency_ms",
+            "filename"
+        ])
+
+        # Data
+        for result in results:
+            overall = result.get("overall", {})
+            writer.writerow([
+                result.get("timestamp", ""),
+                result.get("model_type", ""),
+                result.get("num_examples", 0),
+                overall.get("json_valid_rate", 0),
+                overall.get("field_accuracy", 0),
+                overall.get("avg_latency_ms", 0),
+                result.get("_filename", ""),
+            ])
+
+    click.echo(f"Exported {len(results)} results to {output_path}")

--- a/ccp/commands/inference.py
+++ b/ccp/commands/inference.py
@@ -1,0 +1,161 @@
+"""
+CCP inference command.
+
+Run single inference on a GTM prompt.
+"""
+
+import json
+import time
+
+import click
+import torch
+
+from ccp.config import CCP_SYSTEM_PROMPT
+from ccp.model import load_finetuned_model, clear_memory
+from ccp.utils.parsing import parse_ccp_response, format_inference_prompt, validate_intent_ir
+
+
+@click.command("inference")
+@click.argument("prompt")
+@click.option(
+    "--model-path",
+    default="./models/phi-2",
+    help="Path to base model"
+)
+@click.option(
+    "--adapter-path",
+    default="./ccp-adapter",
+    help="Path to LoRA adapter"
+)
+@click.option(
+    "--max-tokens",
+    default=800,
+    type=int,
+    help="Maximum tokens to generate"
+)
+@click.option(
+    "--temperature",
+    default=0.1,
+    type=float,
+    help="Sampling temperature"
+)
+@click.option(
+    "--raw",
+    is_flag=True,
+    help="Show raw model output instead of parsed"
+)
+@click.option(
+    "--json-only",
+    is_flag=True,
+    help="Output only JSON (for piping)"
+)
+def inference(
+    prompt: str,
+    model_path: str,
+    adapter_path: str,
+    max_tokens: int,
+    temperature: float,
+    raw: bool,
+    json_only: bool,
+):
+    """Run inference on a single GTM prompt.
+
+    Takes a GTM prompt and returns the parsed intent IR.
+
+    Examples:
+
+        # Basic inference
+        ccp inference "Show me my best accounts"
+
+        # Output raw model response
+        ccp inference "Show me my pipeline" --raw
+
+        # JSON output only (for piping)
+        ccp inference "Accounts at risk" --json-only | jq .
+    """
+    if not json_only:
+        click.echo("Loading model...")
+
+    # Load model
+    model, tokenizer = load_finetuned_model(model_path, adapter_path)
+
+    # Format prompt
+    formatted_prompt = format_inference_prompt(prompt, CCP_SYSTEM_PROMPT)
+
+    # Generate
+    if not json_only:
+        click.echo("Generating response...")
+
+    start_time = time.time()
+
+    inputs = tokenizer(formatted_prompt, return_tensors="pt")
+    inputs = {k: v.to(model.device) for k, v in inputs.items()}
+
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=max_tokens,
+            temperature=temperature,
+            do_sample=True,
+            pad_token_id=tokenizer.pad_token_id,
+        )
+
+    response = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    latency_ms = (time.time() - start_time) * 1000
+
+    # Remove prompt from response
+    if formatted_prompt in response:
+        response = response[len(formatted_prompt):]
+
+    if raw:
+        click.echo("\n" + "=" * 60)
+        click.echo("Raw Model Output")
+        click.echo("=" * 60)
+        click.echo(response)
+        click.echo("\n" + "=" * 60)
+        click.echo(f"Latency: {latency_ms:.0f}ms")
+        return
+
+    # Parse response
+    reasoning, intent_ir, is_valid = parse_ccp_response(response)
+
+    if json_only:
+        if is_valid and intent_ir:
+            click.echo(json.dumps(intent_ir, indent=2))
+        else:
+            click.echo(json.dumps({"error": "Failed to parse response", "raw": response}))
+        return
+
+    # Pretty output
+    click.echo("\n" + "=" * 60)
+    click.echo("CCP Inference Result")
+    click.echo("=" * 60)
+
+    click.echo(f"\nPrompt: {prompt}")
+    click.echo(f"Latency: {latency_ms:.0f}ms")
+
+    if reasoning:
+        click.echo(f"\n{'Reasoning':-^60}")
+        click.echo(reasoning)
+
+    if is_valid and intent_ir:
+        click.echo(f"\n{'Intent IR':-^60}")
+        click.echo(json.dumps(intent_ir, indent=2))
+
+        # Validate
+        valid, errors = validate_intent_ir(intent_ir)
+        if valid:
+            click.echo(f"\n{'Status':-^60}")
+            click.echo("VALID: Intent IR passes schema validation")
+        else:
+            click.echo(f"\n{'Validation Errors':-^60}")
+            for error in errors:
+                click.echo(f"  - {error}")
+    else:
+        click.echo(f"\n{'Error':-^60}")
+        click.echo("Failed to parse valid JSON from response")
+        click.echo(f"\nRaw output:\n{response[:500]}...")
+
+    # Cleanup
+    del model
+    clear_memory()

--- a/ccp/commands/train.py
+++ b/ccp/commands/train.py
@@ -1,0 +1,309 @@
+"""
+CCP train command.
+
+Fine-tunes the CCP model with Chain-of-Thought training.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import click
+import torch
+from transformers import (
+    TrainingArguments,
+    Trainer,
+    DataCollatorForLanguageModeling,
+)
+
+from ccp.config import (
+    CCPConfig,
+    ModelConfig,
+    LoraConfig,
+    TrainingConfig,
+    DataConfig,
+    CCP_SYSTEM_PROMPT,
+)
+from ccp.model import (
+    load_tokenizer,
+    load_base_model,
+    apply_lora,
+    clear_memory,
+)
+from ccp.data import load_training_dataset
+
+
+@click.command("train")
+@click.option(
+    "--model-path",
+    default="./models/phi-2",
+    help="Path to base model"
+)
+@click.option(
+    "--data-path",
+    default="./data/ccp_training_with_reasoning.jsonl",
+    help="Path to training data JSONL"
+)
+@click.option(
+    "--output-dir",
+    default="./ccp-adapter",
+    help="Output directory for adapter"
+)
+@click.option(
+    "--epochs",
+    default=3,
+    type=int,
+    help="Number of training epochs"
+)
+@click.option(
+    "--learning-rate", "--lr",
+    default=2e-4,
+    type=float,
+    help="Learning rate"
+)
+@click.option(
+    "--batch-size",
+    default=1,
+    type=int,
+    help="Per-device batch size"
+)
+@click.option(
+    "--gradient-accumulation", "--grad-accum",
+    default=16,
+    type=int,
+    help="Gradient accumulation steps"
+)
+@click.option(
+    "--max-seq-length",
+    default=1024,
+    type=int,
+    help="Maximum sequence length"
+)
+@click.option(
+    "--save-steps",
+    default=100,
+    type=int,
+    help="Save checkpoint every N steps"
+)
+@click.option(
+    "--logging-steps",
+    default=10,
+    type=int,
+    help="Log every N steps"
+)
+@click.option(
+    "--resume-from",
+    default=None,
+    help="Resume from checkpoint (path or 'latest')"
+)
+@click.option(
+    "--device",
+    default="auto",
+    type=click.Choice(["auto", "mps", "cuda", "cpu"]),
+    help="Device to train on"
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Validate setup without training"
+)
+def train(
+    model_path: str,
+    data_path: str,
+    output_dir: str,
+    epochs: int,
+    learning_rate: float,
+    batch_size: int,
+    gradient_accumulation: int,
+    max_seq_length: int,
+    save_steps: int,
+    logging_steps: int,
+    resume_from: str,
+    device: str,
+    dry_run: bool,
+):
+    """Fine-tune CCP model with Chain-of-Thought training.
+
+    Trains a LoRA adapter on the base model using the provided training data.
+    Supports checkpoint resume for recovery from OOM or interruptions.
+
+    Examples:
+
+        # Basic training
+        ccp train
+
+        # Custom parameters
+        ccp train --epochs 5 --learning-rate 1e-4
+
+        # Resume from checkpoint
+        ccp train --resume-from ccp-adapter/checkpoint-400
+
+        # Resume from latest checkpoint
+        ccp train --resume-from latest
+
+        # Dry run to validate setup
+        ccp train --dry-run
+    """
+    click.echo("=" * 60)
+    click.echo("CCP Training - Chain-of-Thought + JSON")
+    click.echo("=" * 60)
+
+    # Resolve device
+    if device == "auto":
+        if torch.backends.mps.is_available():
+            device = "mps"
+        elif torch.cuda.is_available():
+            device = "cuda"
+        else:
+            device = "cpu"
+
+    click.echo(f"\nDevice: {device}")
+    click.echo(f"PyTorch version: {torch.__version__}")
+
+    # Resolve checkpoint path
+    checkpoint_path = None
+    if resume_from:
+        if resume_from == "latest":
+            # Find latest checkpoint in output_dir
+            output_path = Path(output_dir)
+            if output_path.exists():
+                checkpoints = sorted(
+                    output_path.glob("checkpoint-*"),
+                    key=lambda p: int(p.name.split("-")[1]) if p.name.split("-")[1].isdigit() else 0
+                )
+                if checkpoints:
+                    checkpoint_path = str(checkpoints[-1])
+                    click.echo(f"Resuming from latest checkpoint: {checkpoint_path}")
+                else:
+                    click.echo("Warning: No checkpoints found, starting fresh")
+        else:
+            checkpoint_path = resume_from
+            if not Path(checkpoint_path).exists():
+                click.echo(f"Error: Checkpoint not found: {checkpoint_path}", err=True)
+                raise SystemExit(1)
+            click.echo(f"Resuming from checkpoint: {checkpoint_path}")
+
+    # Step 1: Load tokenizer
+    click.echo("\n[1/6] Loading tokenizer...")
+    tokenizer = load_tokenizer(model_path)
+    click.echo(f"  Tokenizer: {tokenizer.__class__.__name__}")
+
+    # Step 2: Load model
+    click.echo("\n[2/6] Loading base model...")
+    model = load_base_model(model_path, device=device, for_training=True)
+    click.echo(f"  Model: {model.__class__.__name__}")
+
+    # Step 3: Apply LoRA
+    click.echo("\n[3/6] Applying LoRA adapters...")
+    lora_config = LoraConfig()
+    model = apply_lora(model, lora_config)
+
+    # Step 4: Load dataset
+    click.echo("\n[4/6] Loading training dataset...")
+    if not Path(data_path).exists():
+        click.echo(f"Error: Training data not found: {data_path}", err=True)
+        raise SystemExit(1)
+
+    tokenized_dataset = load_training_dataset(
+        data_path,
+        tokenizer,
+        max_seq_length=max_seq_length,
+    )
+    click.echo(f"  Loaded {len(tokenized_dataset)} examples")
+
+    # Step 5: Setup training
+    click.echo("\n[5/6] Setting up training...")
+
+    data_collator = DataCollatorForLanguageModeling(
+        tokenizer=tokenizer,
+        mlm=False
+    )
+
+    training_args = TrainingArguments(
+        output_dir=output_dir,
+        per_device_train_batch_size=batch_size,
+        gradient_accumulation_steps=gradient_accumulation,
+        num_train_epochs=epochs,
+        learning_rate=learning_rate,
+        logging_steps=logging_steps,
+        save_steps=save_steps,
+        save_total_limit=3,
+        report_to="none",
+        optim="adamw_torch",
+        bf16=False,
+        fp16=False,
+        # For checkpoint resume
+        save_safetensors=True,
+        load_best_model_at_end=False,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized_dataset,
+        data_collator=data_collator,
+    )
+
+    # Print config summary
+    click.echo(f"\n  Epochs:           {epochs}")
+    click.echo(f"  Batch size:       {batch_size} (effective: {batch_size * gradient_accumulation})")
+    click.echo(f"  Learning rate:    {learning_rate}")
+    click.echo(f"  Max seq length:   {max_seq_length}")
+    click.echo(f"  Save steps:       {save_steps}")
+    click.echo(f"  Output dir:       {output_dir}")
+
+    if dry_run:
+        click.echo("\n" + "=" * 60)
+        click.echo("DRY RUN: Setup validated, skipping training")
+        click.echo("=" * 60)
+        return
+
+    # Step 6: Train
+    click.echo("\n[6/6] Starting training...")
+
+    # Clear memory before training
+    if device == "mps":
+        torch.mps.empty_cache()
+        click.echo("  MPS cache cleared")
+
+    try:
+        if checkpoint_path:
+            trainer.train(resume_from_checkpoint=checkpoint_path)
+        else:
+            trainer.train()
+    except KeyboardInterrupt:
+        click.echo("\n\nTraining interrupted! Saving checkpoint...")
+        trainer.save_model()
+        click.echo(f"Checkpoint saved to {output_dir}")
+        raise SystemExit(130)
+
+    # Save final model
+    click.echo("\n" + "=" * 60)
+    click.echo("Training complete! Saving adapter...")
+
+    model.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+    # Save metadata
+    metadata = {
+        "schema_version": "2.0.0",
+        "base_model": model_path,
+        "training_approach": "chain_of_thought",
+        "output_format": {
+            "reasoning": "<reasoning>...</reasoning>",
+            "intent_ir": "<intent_ir>{JSON}</intent_ir>"
+        },
+        "training_config": {
+            "epochs": epochs,
+            "learning_rate": learning_rate,
+            "batch_size": batch_size,
+            "gradient_accumulation": gradient_accumulation,
+            "max_seq_length": max_seq_length,
+        }
+    }
+
+    with open(os.path.join(output_dir, "ccp_metadata.json"), "w") as f:
+        json.dump(metadata, f, indent=2)
+
+    click.echo(f"\nCCP adapter saved to {output_dir}")
+    click.echo("=" * 60)

--- a/ccp/commands/validate.py
+++ b/ccp/commands/validate.py
@@ -1,0 +1,136 @@
+"""
+CCP validate-data command.
+
+Validates training data schema and content before training.
+"""
+
+import click
+from pathlib import Path
+
+from ccp.data import validate_training_data, load_jsonl
+from ccp.config import (
+    REQUIRED_IR_FIELDS,
+    INTENT_TYPES,
+    MOTIONS,
+    ROLES,
+)
+
+
+@click.command("validate-data")
+@click.option(
+    "--file", "-f",
+    default="./data/ccp_training_with_reasoning.jsonl",
+    help="Path to training data JSONL file"
+)
+@click.option(
+    "--verbose", "-v",
+    is_flag=True,
+    help="Show detailed error information"
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    help="Fail on any warnings (not just errors)"
+)
+def validate_data(file: str, verbose: bool, strict: bool):
+    """Validate training data schema and content.
+
+    Checks that all training examples have:
+    - Valid JSON structure
+    - Required fields (gtm_prompt, intent_ir)
+    - Valid enum values for intent_type, motion, role_assumption, etc.
+    - Proper confidence_scores format
+    """
+    click.echo("=" * 60)
+    click.echo("CCP Training Data Validation")
+    click.echo("=" * 60)
+
+    file_path = Path(file)
+    if not file_path.exists():
+        click.echo(f"\nError: File not found: {file}", err=True)
+        raise SystemExit(1)
+
+    click.echo(f"\nValidating: {file_path}")
+
+    is_valid, stats = validate_training_data(str(file_path), verbose=verbose)
+
+    # Print results
+    click.echo(f"\n{'Results':=^60}")
+    click.echo(f"  Total examples:   {stats['total_examples']}")
+    click.echo(f"  Valid examples:   {stats['valid_examples']}")
+    click.echo(f"  Invalid examples: {stats['invalid_examples']}")
+    click.echo(f"  Has reasoning:    {stats['has_reasoning']}")
+
+    # Field coverage
+    click.echo(f"\n{'Field Coverage':=^60}")
+    total = stats['total_examples']
+    for field in REQUIRED_IR_FIELDS:
+        count = stats['field_coverage'].get(field, 0)
+        pct = (count / total * 100) if total > 0 else 0
+        status = "OK" if pct == 100 else "WARN" if pct > 90 else "FAIL"
+        click.echo(f"  {field:25} {count:5}/{total} ({pct:5.1f}%) [{status}]")
+
+    # Intent type distribution
+    if stats['intent_type_distribution']:
+        click.echo(f"\n{'Intent Type Distribution':=^60}")
+        for intent_type, count in sorted(
+            stats['intent_type_distribution'].items(),
+            key=lambda x: -x[1]
+        ):
+            pct = (count / total * 100) if total > 0 else 0
+            click.echo(f"  {intent_type:25} {count:5} ({pct:5.1f}%)")
+
+    # Motion distribution
+    if stats['motion_distribution']:
+        click.echo(f"\n{'Motion Distribution':=^60}")
+        for motion, count in sorted(
+            stats['motion_distribution'].items(),
+            key=lambda x: -x[1]
+        ):
+            pct = (count / total * 100) if total > 0 else 0
+            click.echo(f"  {motion:25} {count:5} ({pct:5.1f}%)")
+
+    # Errors
+    if stats['errors'] and verbose:
+        click.echo(f"\n{'Errors':=^60}")
+        for error in stats['errors'][:20]:  # Limit to first 20
+            if isinstance(error, dict):
+                click.echo(f"\n  Example {error['index']}: {error['prompt']}...")
+                for e in error['errors']:
+                    click.echo(f"    - {e}")
+            else:
+                click.echo(f"  {error}")
+
+        if len(stats['errors']) > 20:
+            click.echo(f"\n  ... and {len(stats['errors']) - 20} more errors")
+
+    # Final status
+    click.echo("\n" + "=" * 60)
+    if is_valid:
+        click.echo("PASSED: All training data is valid")
+        click.echo("=" * 60)
+    else:
+        click.echo("FAILED: Training data has validation errors", err=True)
+        click.echo("=" * 60)
+        raise SystemExit(1)
+
+    # Warnings (non-fatal unless --strict)
+    warnings = []
+    if stats['has_reasoning'] < stats['total_examples']:
+        missing = stats['total_examples'] - stats['has_reasoning']
+        warnings.append(f"{missing} examples missing reasoning field")
+
+    for field in REQUIRED_IR_FIELDS:
+        count = stats['field_coverage'].get(field, 0)
+        if count < stats['total_examples']:
+            missing = stats['total_examples'] - count
+            warnings.append(f"{missing} examples missing {field}")
+
+    if warnings:
+        click.echo("\nWarnings:")
+        for w in warnings:
+            click.echo(f"  - {w}")
+
+        if strict:
+            click.echo("\n--strict mode: treating warnings as errors")
+            raise SystemExit(1)

--- a/ccp/config.py
+++ b/ccp/config.py
@@ -1,0 +1,229 @@
+"""
+CCP Configuration Module
+
+Centralized configuration for all CCP operations.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, List
+
+
+@dataclass
+class ModelConfig:
+    """Model and adapter configuration."""
+    base_model_path: str = "./models/phi-2"
+    adapter_path: str = "./ccp-adapter"
+    device: str = "auto"  # auto, mps, cuda, cpu
+
+    def resolve_device(self) -> str:
+        """Resolve 'auto' to actual device."""
+        if self.device != "auto":
+            return self.device
+
+        import torch
+        if torch.backends.mps.is_available():
+            return "mps"
+        elif torch.cuda.is_available():
+            return "cuda"
+        return "cpu"
+
+
+@dataclass
+class LoraConfig:
+    """LoRA adapter configuration."""
+    r: int = 16
+    alpha: int = 32
+    dropout: float = 0.05
+    target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
+    bias: str = "none"
+    task_type: str = "CAUSAL_LM"
+
+
+@dataclass
+class TrainingConfig:
+    """Training hyperparameters."""
+    num_epochs: int = 3
+    learning_rate: float = 2e-4
+    batch_size: int = 1
+    gradient_accumulation_steps: int = 16
+    max_seq_length: int = 1024
+    logging_steps: int = 10
+    save_steps: int = 100
+    save_total_limit: int = 3
+    warmup_steps: int = 0
+    weight_decay: float = 0.0
+
+    # Checkpoint resume
+    resume_from: Optional[str] = None
+
+
+@dataclass
+class DataConfig:
+    """Data paths and settings."""
+    training_data_path: str = "./data/ccp_training_with_reasoning.jsonl"
+    eval_data_path: str = "./data/ccp_eval.jsonl"
+    results_dir: str = "./eval_results"
+
+
+@dataclass
+class CCPConfig:
+    """Main CCP configuration combining all sub-configs."""
+    model: ModelConfig = field(default_factory=ModelConfig)
+    lora: LoraConfig = field(default_factory=LoraConfig)
+    training: TrainingConfig = field(default_factory=TrainingConfig)
+    data: DataConfig = field(default_factory=DataConfig)
+
+    # Schema version
+    ir_schema_version: str = "2.0.0"
+
+
+# System prompt for CCP v2 (Chain-of-Thought)
+CCP_SYSTEM_PROMPT = """You are the Phoenix Context Collapse Parser (CCP). Your job is to transform ambiguous GTM (Go-To-Market) prompts into structured GTM Intent IR.
+
+IMPORTANT: You must REASON about the request before producing structured output. This ensures you understand the GTM semantics, not just the JSON format.
+
+Given a user's GTM request:
+1. First, analyze the prompt in a <reasoning> section:
+   - Identify explicit signals (keywords, jargon, metrics mentioned)
+   - Infer implicit context (role, motion, time horizon)
+   - Note any ambiguities that affect confidence
+   - Explain WHY you chose each field value
+
+2. Then, output the structured intent in an <intent_ir> section as JSON with:
+   - intent_type: The primary intent category
+   - motion: The GTM motion (outbound, expansion, renewal, etc.)
+   - role_assumption: Inferred user role
+   - account_scope: Which accounts (net_new, existing, all)
+   - icp_selector: Which ICP to apply (default, or specific product/segment)
+   - icp_resolution_required: true if ICP needs downstream resolution
+   - geography_scope: Geographic filter if mentioned (null if global)
+   - time_horizon: Time scope for the request
+   - output_format: How results should be presented
+   - confidence_scores: 0.0-1.0 confidence for each inferred field
+   - assumptions_applied: List of assumptions made
+   - clarification_needed: true if request is too ambiguous
+
+Format your response EXACTLY as:
+<reasoning>
+[Your analysis here]
+</reasoning>
+
+<intent_ir>
+[Valid JSON here]
+</intent_ir>"""
+
+
+# GTM Intent IR Schema definitions
+INTENT_TYPES = [
+    "account_discovery",
+    "pipeline_analysis",
+    "expansion_identification",
+    "churn_risk_assessment",
+    "lead_prioritization",
+    "territory_planning",
+    "forecast_review",
+    "competitive_analysis",
+    "engagement_summary",
+    # Extended types from training data
+    "performance_tracking",
+    "qualification_analysis",
+    "lead_scoring",
+    "deal_review",
+    "quota_analysis",
+    "opportunity_scoring",
+    "metrics_analysis",
+    "expansion_opportunity",
+    "resource_planning",
+    "team_analysis",
+    "meeting_prep",
+    "relationship_building",
+    "prospecting_analysis",
+    "pipeline_generation",
+    "health_scoring",
+    "activity_tracking",
+]
+
+MOTIONS = [
+    "outbound",
+    "inbound",
+    "expansion",
+    "renewal",
+    "churn_prevention",
+]
+
+ROLES = [
+    "sales_rep",
+    "sales_manager",
+    "revops",
+    "marketing",
+    "cs",
+    "exec",
+    "sdr",   # Sales Development Representative
+    "bdr",   # Business Development Representative
+    "ae",    # Account Executive
+    "am",    # Account Manager
+    "csm",   # Customer Success Manager
+    "cro",   # Chief Revenue Officer
+    "vp_sales",
+    "director",
+]
+
+ACCOUNT_SCOPES = [
+    "net_new",
+    "existing",
+    "churned",
+    "all",
+    "new",  # Alias for net_new in some training data
+]
+
+TIME_HORIZONS = [
+    "immediate",
+    "this_week",
+    "this_month",
+    "this_quarter",
+    "this_year",
+    "next_quarter",
+    "next_month",
+    "custom",
+]
+
+OUTPUT_FORMATS = [
+    "list",
+    "summary",
+    "detailed",
+    "export",
+    "visualization",
+]
+
+# Required fields for validation (core fields that must be present)
+REQUIRED_IR_FIELDS = [
+    "intent_type",
+    "motion",
+    "role_assumption",
+    "account_scope",
+    "time_horizon",
+    "confidence_scores",
+    "assumptions_applied",
+]
+
+# Optional fields (nice to have but not required for training)
+OPTIONAL_IR_FIELDS = [
+    "output_format",
+    "clarification_needed",
+    "icp_selector",
+    "icp_resolution_required",
+    "geography_scope",
+]
+
+# Fields used for evaluation scoring
+EVAL_FIELDS = [
+    "intent_type",
+    "motion",
+    "role_assumption",
+    "account_scope",
+    "time_horizon",
+    "geography_scope",
+    "output_format",
+    "clarification_needed",
+]

--- a/ccp/data.py
+++ b/ccp/data.py
@@ -1,0 +1,232 @@
+"""
+Data loading and validation utilities for CCP.
+
+Handles loading, validating, and processing training and evaluation data.
+"""
+
+import json
+from pathlib import Path
+from typing import List, Dict, Any, Optional, Tuple
+from datasets import load_dataset, Dataset
+
+from ccp.config import (
+    CCP_SYSTEM_PROMPT,
+    REQUIRED_IR_FIELDS,
+    INTENT_TYPES,
+    MOTIONS,
+    ROLES,
+    ACCOUNT_SCOPES,
+    TIME_HORIZONS,
+    OUTPUT_FORMATS,
+)
+from ccp.utils.parsing import validate_intent_ir
+
+
+def load_jsonl(file_path: str) -> List[Dict[str, Any]]:
+    """
+    Load a JSONL file.
+
+    Args:
+        file_path: Path to JSONL file
+
+    Returns:
+        List of parsed JSON objects
+    """
+    data = []
+    with open(file_path, 'r') as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON at line {line_num}: {e}")
+    return data
+
+
+def validate_training_data(file_path: str, verbose: bool = False) -> Tuple[bool, Dict[str, Any]]:
+    """
+    Validate training data schema and content.
+
+    Args:
+        file_path: Path to training data JSONL
+        verbose: Print detailed output
+
+    Returns:
+        Tuple of (is_valid, stats_dict)
+    """
+    stats = {
+        "total_examples": 0,
+        "valid_examples": 0,
+        "invalid_examples": 0,
+        "errors": [],
+        "field_coverage": {},
+        "intent_type_distribution": {},
+        "motion_distribution": {},
+        "has_reasoning": 0,
+    }
+
+    try:
+        data = load_jsonl(file_path)
+    except Exception as e:
+        stats["errors"].append(f"Failed to load file: {e}")
+        return False, stats
+
+    stats["total_examples"] = len(data)
+
+    for idx, example in enumerate(data):
+        example_errors = []
+
+        # Check required top-level fields
+        if "gtm_prompt" not in example:
+            example_errors.append("Missing 'gtm_prompt' field")
+
+        if "intent_ir" not in example:
+            example_errors.append("Missing 'intent_ir' field")
+        else:
+            intent_ir = example["intent_ir"]
+
+            # Handle string vs dict
+            if isinstance(intent_ir, str):
+                try:
+                    intent_ir = json.loads(intent_ir)
+                except json.JSONDecodeError:
+                    example_errors.append("intent_ir is invalid JSON string")
+                    intent_ir = None
+
+            if intent_ir:
+                is_valid, ir_errors = validate_intent_ir(intent_ir)
+                example_errors.extend(ir_errors)
+
+                # Track distributions
+                if "intent_type" in intent_ir:
+                    it = intent_ir["intent_type"]
+                    stats["intent_type_distribution"][it] = \
+                        stats["intent_type_distribution"].get(it, 0) + 1
+
+                if "motion" in intent_ir:
+                    m = intent_ir["motion"]
+                    stats["motion_distribution"][m] = \
+                        stats["motion_distribution"].get(m, 0) + 1
+
+                # Track field coverage
+                for field in REQUIRED_IR_FIELDS:
+                    if field in intent_ir:
+                        stats["field_coverage"][field] = \
+                            stats["field_coverage"].get(field, 0) + 1
+
+        # Check reasoning (optional but tracked)
+        if "reasoning" in example and example["reasoning"]:
+            stats["has_reasoning"] += 1
+
+        if example_errors:
+            stats["invalid_examples"] += 1
+            if verbose:
+                stats["errors"].append({
+                    "index": idx,
+                    "prompt": example.get("gtm_prompt", "N/A")[:50],
+                    "errors": example_errors
+                })
+        else:
+            stats["valid_examples"] += 1
+
+    is_valid = stats["invalid_examples"] == 0
+    return is_valid, stats
+
+
+def load_training_dataset(
+    file_path: str,
+    tokenizer,
+    max_seq_length: int = 1024,
+    system_prompt: str = CCP_SYSTEM_PROMPT
+) -> Dataset:
+    """
+    Load and prepare training dataset.
+
+    Args:
+        file_path: Path to training JSONL
+        tokenizer: Tokenizer to use
+        max_seq_length: Maximum sequence length
+        system_prompt: System prompt for formatting
+
+    Returns:
+        Tokenized HuggingFace Dataset
+    """
+    # Load raw dataset
+    dataset = load_dataset(
+        "json",
+        data_files=file_path,
+        split="train"
+    )
+
+    # Format examples with CoT template
+    def format_example(example):
+        prompt = example["gtm_prompt"].strip()
+        reasoning = example.get("reasoning", "").strip()
+        if not reasoning:
+            reasoning = "- Analyzing prompt for GTM signals\n- Inferring context from keywords"
+
+        ir_json = example["intent_ir"]
+        if isinstance(ir_json, str):
+            ir_output = ir_json
+        else:
+            ir_output = json.dumps(ir_json, indent=2)
+
+        text = f"""<s>[INST] {system_prompt}
+
+User request: {prompt} [/INST]
+<reasoning>
+{reasoning}
+</reasoning>
+
+<intent_ir>
+{ir_output}
+</intent_ir></s>"""
+
+        return {"text": text}
+
+    dataset = dataset.map(format_example)
+
+    # Tokenize
+    def tokenize(batch):
+        return tokenizer(
+            batch["text"],
+            truncation=True,
+            max_length=max_seq_length,
+            padding=False,
+        )
+
+    tokenized_dataset = dataset.map(
+        tokenize,
+        remove_columns=dataset.column_names
+    )
+
+    return tokenized_dataset
+
+
+def load_eval_dataset(
+    file_path: str,
+    category: Optional[str] = None,
+    limit: Optional[int] = None
+) -> List[Dict[str, Any]]:
+    """
+    Load evaluation dataset with optional filtering.
+
+    Args:
+        file_path: Path to eval JSONL
+        category: Filter by category (standard, slang, adversarial, ambiguous)
+        limit: Limit number of examples
+
+    Returns:
+        List of eval examples
+    """
+    data = load_jsonl(file_path)
+
+    if category:
+        data = [d for d in data if d.get("category") == category]
+
+    if limit:
+        data = data[:limit]
+
+    return data

--- a/ccp/model.py
+++ b/ccp/model.py
@@ -1,0 +1,173 @@
+"""
+Model loading utilities for CCP.
+
+Handles loading base models, tokenizers, and LoRA adapters.
+"""
+
+import torch
+from pathlib import Path
+from typing import Tuple, Optional
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel, LoraConfig as PeftLoraConfig, get_peft_model
+
+from ccp.config import ModelConfig, LoraConfig
+
+
+def load_tokenizer(model_path: str) -> AutoTokenizer:
+    """
+    Load tokenizer from model path.
+
+    Args:
+        model_path: Path to the model directory
+
+    Returns:
+        Loaded tokenizer with pad token set
+    """
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_path,
+        local_files_only=True,
+    )
+
+    # Ensure pad token is set
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    return tokenizer
+
+
+def load_base_model(
+    model_path: str,
+    device: str = "auto",
+    for_training: bool = False
+) -> AutoModelForCausalLM:
+    """
+    Load base model for training or inference.
+
+    Args:
+        model_path: Path to the model directory
+        device: Device to load model on (auto, mps, cuda, cpu)
+        for_training: If True, enables gradient checkpointing
+
+    Returns:
+        Loaded model
+    """
+    # Resolve device
+    if device == "auto":
+        if torch.backends.mps.is_available():
+            device = "mps"
+        elif torch.cuda.is_available():
+            device = "cuda"
+        else:
+            device = "cpu"
+
+    print(f"  Loading model on device: {device}")
+
+    # Device map for loading
+    device_map = {"": device}
+
+    # Load model
+    # Note: MPS doesn't support bitsandbytes quantization, use float32
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path,
+        torch_dtype=torch.float32,
+        device_map=device_map,
+        local_files_only=True,
+    )
+
+    if for_training:
+        model.config.use_cache = False
+        model.gradient_checkpointing_enable()
+
+    return model
+
+
+def apply_lora(
+    model: AutoModelForCausalLM,
+    lora_config: LoraConfig
+) -> AutoModelForCausalLM:
+    """
+    Apply LoRA adapters to a model for training.
+
+    Args:
+        model: Base model to apply LoRA to
+        lora_config: LoRA configuration
+
+    Returns:
+        Model with LoRA adapters applied
+    """
+    peft_config = PeftLoraConfig(
+        r=lora_config.r,
+        lora_alpha=lora_config.alpha,
+        target_modules=lora_config.target_modules,
+        lora_dropout=lora_config.dropout,
+        bias=lora_config.bias,
+        task_type=lora_config.task_type,
+    )
+
+    model = get_peft_model(model, peft_config)
+    model.print_trainable_parameters()
+
+    return model
+
+
+def load_finetuned_model(
+    base_model_path: str,
+    adapter_path: str,
+    device: str = "auto"
+) -> Tuple[AutoModelForCausalLM, AutoTokenizer]:
+    """
+    Load a fine-tuned model with LoRA adapter for inference.
+
+    Args:
+        base_model_path: Path to base model
+        adapter_path: Path to LoRA adapter
+        device: Device to load on
+
+    Returns:
+        Tuple of (model, tokenizer)
+    """
+    # Resolve device
+    if device == "auto":
+        if torch.backends.mps.is_available():
+            device = "mps"
+        elif torch.cuda.is_available():
+            device = "cuda"
+        else:
+            device = "cpu"
+
+    print(f"  Loading fine-tuned model on device: {device}")
+
+    # Load tokenizer
+    tokenizer = load_tokenizer(base_model_path)
+
+    # Load base model
+    model = AutoModelForCausalLM.from_pretrained(
+        base_model_path,
+        torch_dtype=torch.float32,
+        device_map={"": device},
+        local_files_only=True,
+    )
+
+    # Load LoRA adapter
+    model = PeftModel.from_pretrained(model, adapter_path)
+    model.eval()
+
+    return model, tokenizer
+
+
+def clear_memory(device: str = "auto"):
+    """Clear GPU/MPS memory cache."""
+    import gc
+    gc.collect()
+
+    if device == "auto":
+        if torch.backends.mps.is_available():
+            device = "mps"
+        elif torch.cuda.is_available():
+            device = "cuda"
+
+    if device == "mps" and torch.backends.mps.is_available():
+        torch.mps.empty_cache()
+    elif device == "cuda" and torch.cuda.is_available():
+        torch.cuda.empty_cache()

--- a/ccp/utils/__init__.py
+++ b/ccp/utils/__init__.py
@@ -1,0 +1,1 @@
+"""CCP utilities."""

--- a/ccp/utils/parsing.py
+++ b/ccp/utils/parsing.py
@@ -1,0 +1,194 @@
+"""
+Response parsing utilities for CCP.
+
+Handles extraction and validation of reasoning and intent_ir from model outputs.
+"""
+
+import json
+import re
+from typing import Dict, Any, Tuple, Optional
+
+from ccp.config import (
+    REQUIRED_IR_FIELDS,
+    INTENT_TYPES,
+    MOTIONS,
+    ROLES,
+    ACCOUNT_SCOPES,
+    TIME_HORIZONS,
+    OUTPUT_FORMATS,
+)
+
+
+def parse_ccp_response(response: str) -> Tuple[Optional[str], Optional[Dict], bool]:
+    """
+    Parse a CCP model response to extract reasoning and intent_ir.
+
+    Args:
+        response: Raw model output string
+
+    Returns:
+        Tuple of (reasoning_text, intent_ir_dict, is_valid_json)
+    """
+    reasoning = None
+    intent_ir = None
+    is_valid = False
+
+    # Extract reasoning section
+    reasoning_match = re.search(
+        r"<reasoning>(.*?)</reasoning>",
+        response,
+        re.DOTALL | re.IGNORECASE
+    )
+    if reasoning_match:
+        reasoning = reasoning_match.group(1).strip()
+
+    # Extract intent_ir section
+    intent_match = re.search(
+        r"<intent_ir>(.*?)</intent_ir>",
+        response,
+        re.DOTALL | re.IGNORECASE
+    )
+
+    if intent_match:
+        json_str = intent_match.group(1).strip()
+        try:
+            intent_ir = json.loads(json_str)
+            is_valid = True
+        except json.JSONDecodeError:
+            # Try to extract JSON from the string (might have extra content)
+            json_match = re.search(r"\{.*\}", json_str, re.DOTALL)
+            if json_match:
+                try:
+                    intent_ir = json.loads(json_match.group(0))
+                    is_valid = True
+                except json.JSONDecodeError:
+                    pass
+
+    # Fallback: try to find raw JSON in response
+    if intent_ir is None:
+        json_match = re.search(r"\{.*\}", response, re.DOTALL)
+        if json_match:
+            try:
+                intent_ir = json.loads(json_match.group(0))
+                is_valid = True
+            except json.JSONDecodeError:
+                pass
+
+    return reasoning, intent_ir, is_valid
+
+
+def validate_intent_ir(intent_ir: Dict[str, Any]) -> Tuple[bool, list]:
+    """
+    Validate an intent_ir dictionary against the schema.
+
+    Args:
+        intent_ir: The parsed intent IR dictionary
+
+    Returns:
+        Tuple of (is_valid, list_of_errors)
+    """
+    errors = []
+
+    if not isinstance(intent_ir, dict):
+        return False, ["intent_ir is not a dictionary"]
+
+    # Check required fields
+    for field in REQUIRED_IR_FIELDS:
+        if field not in intent_ir:
+            errors.append(f"Missing required field: {field}")
+
+    # Validate enum fields
+    if "intent_type" in intent_ir:
+        if intent_ir["intent_type"] not in INTENT_TYPES:
+            errors.append(f"Invalid intent_type: {intent_ir['intent_type']}")
+
+    if "motion" in intent_ir:
+        if intent_ir["motion"] not in MOTIONS:
+            errors.append(f"Invalid motion: {intent_ir['motion']}")
+
+    if "role_assumption" in intent_ir:
+        if intent_ir["role_assumption"] not in ROLES:
+            errors.append(f"Invalid role_assumption: {intent_ir['role_assumption']}")
+
+    if "account_scope" in intent_ir:
+        if intent_ir["account_scope"] not in ACCOUNT_SCOPES:
+            errors.append(f"Invalid account_scope: {intent_ir['account_scope']}")
+
+    if "time_horizon" in intent_ir:
+        if intent_ir["time_horizon"] not in TIME_HORIZONS:
+            errors.append(f"Invalid time_horizon: {intent_ir['time_horizon']}")
+
+    if "output_format" in intent_ir:
+        if intent_ir["output_format"] not in OUTPUT_FORMATS:
+            errors.append(f"Invalid output_format: {intent_ir['output_format']}")
+
+    # Validate confidence_scores
+    if "confidence_scores" in intent_ir:
+        scores = intent_ir["confidence_scores"]
+        if not isinstance(scores, dict):
+            errors.append("confidence_scores must be a dictionary")
+        else:
+            for key, value in scores.items():
+                if not isinstance(value, (int, float)) or not 0 <= value <= 1:
+                    errors.append(f"Invalid confidence score for {key}: {value}")
+
+    # Validate assumptions_applied
+    if "assumptions_applied" in intent_ir:
+        if not isinstance(intent_ir["assumptions_applied"], list):
+            errors.append("assumptions_applied must be a list")
+
+    # Validate clarification_needed
+    if "clarification_needed" in intent_ir:
+        if not isinstance(intent_ir["clarification_needed"], bool):
+            errors.append("clarification_needed must be a boolean")
+
+    return len(errors) == 0, errors
+
+
+def format_training_example(
+    gtm_prompt: str,
+    reasoning: str,
+    intent_ir: Dict[str, Any],
+    system_prompt: str
+) -> str:
+    """
+    Format a training example with Chain-of-Thought structure.
+
+    Args:
+        gtm_prompt: The user's GTM prompt
+        reasoning: The reasoning explanation
+        intent_ir: The intent IR dictionary
+        system_prompt: The system prompt to use
+
+    Returns:
+        Formatted training string
+    """
+    if isinstance(intent_ir, str):
+        ir_output = intent_ir
+    else:
+        ir_output = json.dumps(intent_ir, indent=2)
+
+    return f"""<s>[INST] {system_prompt}
+
+User request: {gtm_prompt} [/INST]
+<reasoning>
+{reasoning}
+</reasoning>
+
+<intent_ir>
+{ir_output}
+</intent_ir></s>"""
+
+
+def format_inference_prompt(gtm_prompt: str, system_prompt: str) -> str:
+    """
+    Format a prompt for inference.
+
+    Args:
+        gtm_prompt: The user's GTM prompt
+        system_prompt: The system prompt to use
+
+    Returns:
+        Formatted inference prompt
+    """
+    return f"<s>[INST] {system_prompt}\n\nUser request: {gtm_prompt} [/INST]\n"

--- a/ccp_cli.py
+++ b/ccp_cli.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""
+CCP CLI Entry Point
+
+Run with: python ccp_cli.py <command> [options]
+"""
+
+from ccp.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/train_ccp_v2.py
+++ b/train_ccp_v2.py
@@ -29,8 +29,8 @@ IR_SCHEMA_VERSION = "2.0.0"
 NUM_EPOCHS = 3
 LEARNING_RATE = 2e-4
 BATCH_SIZE = 1
-GRAD_ACCUM_STEPS = 8
-MAX_SEQ_LENGTH = 1536
+GRAD_ACCUM_STEPS = 16  # Increased to compensate for smaller batch
+MAX_SEQ_LENGTH = 1024  # Reduced for memory efficiency on MPS
 
 # ===== SYSTEM PROMPT =====
 CCP_SYSTEM_PROMPT = """You are the Phoenix Context Collapse Parser (CCP). Your job is to transform ambiguous GTM (Go-To-Market) prompts into structured GTM Intent IR.
@@ -204,6 +204,11 @@ User request: {prompt} [/INST]
     print(f"  Learning rate: {LEARNING_RATE}")
     print(f"  Max sequence length: {MAX_SEQ_LENGTH}")
     print()
+
+    # Clear MPS cache before training to free memory
+    if torch.backends.mps.is_available():
+        torch.mps.empty_cache()
+        print("  MPS cache cleared before training")
 
     trainer.train()
 


### PR DESCRIPTION
## Summary

Refactors the Jupyter notebook fine-tuning workflow into a modular CLI package, enabling:
- Background/automated training runs
- Independent execution of specific steps
- Checkpoint resume for OOM recovery
- Better CI/CD integration

### New CLI Commands

| Command | Description |
|---------|-------------|
| `ccp validate-data` | Validate training data schema and content |
| `ccp train` | Fine-tune the model with checkpoint resume support |
| `ccp eval` | Evaluate model performance |
| `ccp inference` | Run inference on a single GTM prompt |
| `ccp history` | View and analyze evaluation history |

### Usage Examples

```bash
# Validate training data
python ccp_cli.py validate-data

# Train with checkpoint resume
python ccp_cli.py train --resume-from latest

# Quick evaluation
python ccp_cli.py eval --quick

# Single inference
python ccp_cli.py inference "Show me my best accounts"

# View history
python ccp_cli.py history --compare 2
```

### Package Structure

```
ccp/
├── __init__.py
├── cli.py           # Click CLI entry point
├── config.py        # Centralized configuration
├── model.py         # Model loading utilities
├── data.py          # Data loading/validation
├── commands/
│   ├── validate.py  # validate-data command
│   ├── train.py     # train command
│   ├── eval.py      # eval command
│   ├── inference.py # inference command
│   └── history.py   # history command
└── utils/
    └── parsing.py   # Response parsing utilities
```

### Additional Changes

- Memory optimizations for `train_ccp_v2.py` (reduced seq length, MPS cache clearing)
- Extended schema validation supporting all GTM roles and intent types from training data
- Updated CLAUDE.md with comprehensive CLI documentation

## Test Plan

- [x] `ccp --help` shows all commands
- [x] `ccp validate-data` passes on training data (1,278 examples)
- [x] `ccp train --dry-run` validates setup without training
- [x] `ccp history` displays evaluation results

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)